### PR TITLE
Fix for new cri-fs bind improvements

### DIFF
--- a/p5rpc.modloader/Merging/BfMerger.cs
+++ b/p5rpc.modloader/Merging/BfMerger.cs
@@ -202,6 +202,7 @@ internal class BfMerger : IFileMerger
         {
             _logger.Info("Loading Merged BF {0} from Cache ({1})", route, mergedCachePath);
             _bfEmulator.RegisterBf(mergedCachePath, bfPath);
+            _utils.ReplaceFileInBinderInput(pathToFileMap, route, mergedCachePath);
             return;
         }
 


### PR DESCRIPTION
This is needed for the upcoming improvement to [CriFs.V2.Hook](https://github.com/Sewer56/CriFs.V2.Hook.ReloadedII) to work with Persona Essentials and BF Emulator.