### PR TITLE
Fix cached files not being updated when one mod registers multiple sources for a file

### DIFF
--- a/Persona.Merger.Common/Cache/MergedFileCache.cs
+++ b/Persona.Merger.Common/Cache/MergedFileCache.cs
@@ -62,9 +62,9 @@ public class MergedFileCache
         cachedPath = null;
         if (!KeyToFile.TryGetValue(key, out var value))
             return false;
-        
-        // Note: Checking length of 2 collections is not necessary, key uses character invalid
-        // in modIds, and thus should never have collisions where source count would be different.
+
+        if (sources.Length != value.Sources.Length)
+            return false;
         
         // We write it this way however to elide bounds checks.
         fixed (CachedFileSource* currentValueSource = &value.Sources[0])


### PR DESCRIPTION
Previously the cache assumed that one modId could only have one associated file (which was valid when this was only used for tbl merging). 
Now, however, it is possible for one mod to register multiple sources for the same file (for example I do this to add "configurable" parts to files with bf emulator). Because of this there were cases where the cache wouldn't be updated as the sources lengths were not compared. This pr fixes that.