### PR TITLE
Fix crash on boot when merging P4G ENCOUNT.TBL

### DIFF
--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment1Resolver.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment1Resolver.cs
@@ -1,0 +1,14 @@
+﻿using Sewer56.StructuredDiff.Interfaces;
+
+namespace Persona.Merger.Patching.Tbl.FieldResolvers.P4G.Encounter;
+
+public struct EncountSegment1Resolver : IEncoderFieldResolver
+{
+    public bool Resolve(nuint offset, out int moveBy, out int length)
+    {
+        // Segment is undocumented so assume it's all individual bytes
+        moveBy = 0;
+        length = 1;
+        return false;
+    }
+}

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment2Resolver.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment2Resolver.cs
@@ -1,0 +1,14 @@
+﻿using Sewer56.StructuredDiff.Interfaces;
+
+namespace Persona.Merger.Patching.Tbl.FieldResolvers.P4G.Encounter;
+
+public struct EncountSegment2Resolver : IEncoderFieldResolver
+{
+    public bool Resolve(nuint offset, out int moveBy, out int length)
+    {
+        // Segment is undocumented so assume it's all individual bytes
+        moveBy = 0;
+        length = 1;
+        return false;
+    }
+}

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment3Resolver.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment3Resolver.cs
@@ -1,0 +1,14 @@
+﻿using Sewer56.StructuredDiff.Interfaces;
+
+namespace Persona.Merger.Patching.Tbl.FieldResolvers.P4G.Encounter;
+
+public struct EncountSegment3Resolver : IEncoderFieldResolver
+{
+    public bool Resolve(nuint offset, out int moveBy, out int length)
+    {
+        // Segment is undocumented so assume it's all individual bytes
+        moveBy = 0;
+        length = 1;
+        return false;
+    }
+}

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment4Resolver.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EncountSegment4Resolver.cs
@@ -1,0 +1,14 @@
+﻿using Sewer56.StructuredDiff.Interfaces;
+
+namespace Persona.Merger.Patching.Tbl.FieldResolvers.P4G.Encounter;
+
+public struct EncountSegment4Resolver : IEncoderFieldResolver
+{
+    public bool Resolve(nuint offset, out int moveBy, out int length)
+    {
+        // Segment is undocumented so assume it's all individual bytes
+        moveBy = 0;
+        length = 1;
+        return false;
+    }
+}

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EnemyEncounterResolver.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/Encounter/EnemyEncounterResolver.cs
@@ -2,7 +2,7 @@
 
 namespace Persona.Merger.Patching.Tbl.FieldResolvers.P4G.Encounter;
 
-public struct EncounterResolver : IEncoderFieldResolver
+public struct EnemyEncounterResolver : IEncoderFieldResolver
 {
     public bool Resolve(nuint offset, out int moveBy, out int length)
     {

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/P4GTblPatcher.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/P4GTblPatcher.cs
@@ -85,7 +85,11 @@ public struct P4GTblPatcher
                     DiffSegment(patch, newSegments[8], originalSegments[8], new AICalcSegment8Resolver());
                     break;
                 case TblType.Encount:
-                    DiffSegment(patch, newSegments[0], originalSegments[0], new EncounterResolver());
+                    DiffSegment(patch, newSegments[0], originalSegments[0], new EnemyEncounterResolver());
+                    DiffSegment(patch, newSegments[1], originalSegments[1], new EncountSegment1Resolver());
+                    DiffSegment(patch, newSegments[2], originalSegments[2], new EncountSegment2Resolver());
+                    DiffSegment(patch, newSegments[3], originalSegments[3], new EncountSegment3Resolver());
+                    DiffSegment(patch, newSegments[4], originalSegments[4], new EncountSegment4Resolver());
                     break;
                 case TblType.Effect:
                     DiffSegment(patch, newSegments[0], originalSegments[0], new EffectResolver());

--- a/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/P4GTblSegmentFinder.cs
+++ b/Persona.Merger.Common/Patching/Tbl/FieldResolvers/P4G/P4GTblSegmentFinder.cs
@@ -47,7 +47,7 @@ public unsafe struct P4GTblSegmentFinder
         {
             TblType.Persona => 6,
             TblType.AiCalc => 11,
-            TblType.Encount => 1,
+            TblType.Encount => 5,
             TblType.Skill => 2,
             TblType.Item => 3,
             TblType.Unit => 3,


### PR DESCRIPTION
Turns out I had a bad template for ENCOUNT.TBL which was missing multiple segments, hence if it was merged it would always cause a crash on boot 🫠

That's now fixed