### PR TITLE
Added support for Game Pass exe of Persona 4 Golden due to exe name

### DIFF
--- a/p5rpc.modloader/Mod.cs
+++ b/p5rpc.modloader/Mod.cs
@@ -82,13 +82,13 @@ public partial class Mod : ModBase // <= Do not Remove.
         var fileName = Path.GetFileName(mainModule.FileName);
         if (fileName.StartsWith("p5r", StringComparison.OrdinalIgnoreCase))
             Game = Game.P5R;
-        else if (fileName.StartsWith("p4g", StringComparison.OrdinalIgnoreCase))
+        else if (fileName.StartsWith("p4g", StringComparison.OrdinalIgnoreCase) || fileName.StartsWith("p4pc_DT_mc", StringComparison.OrdinalIgnoreCase))
             Game = Game.P4G;        
         else if (fileName.StartsWith("p3p", StringComparison.OrdinalIgnoreCase))
             Game = Game.P3P;
         else
             _logger.Warning("Executable name does not match any known game. Will use Persona 5 Royal profile.\n" +
-                            "Consider renaming your EXE back to something that starts with 'p4g' or 'p5r'.");
+                            "Consider renaming your EXE back to something that starts with 'p4g' or 'p4pc_DT_mc' or 'p5r'.");
 
         // Read merged file cache in background.
         _createMergedFileCacheTask = Task.Run(async () =>


### PR DESCRIPTION
Similar to the PR in https://github.com/Sewer56/FileEmulationFramework/pull/12, mod needs to be updated to support Game Pass exe name of P4G, which is p4pc_DT_mc.exe