### PR TITLE
Fix Json serialisation error due to trimming Persona.Merger.Common

### DIFF
--- a/p5rpc.modloader/p5rpc.modloader.csproj
+++ b/p5rpc.modloader/p5rpc.modloader.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
 
     <ReloadedLinkRoots Include="p5rpc.modloader" />
+    <ReloadedLinkRoots Include="Persona.Merger.Common" />
     <!-- Add assemblies to be trimmed. You might need to add their dependencies too!  -->
     <!-- <ReloadedLinkAssemblies Include="Reloaded.Memory" /> -->
   </ItemGroup>


### PR DESCRIPTION
The error that everyone was getting as of release 2.9.0 was due to trimming not playing nice with the Json serialisation in the `Persona.Merger.Common` project which is used to read the json files with info about the cache. I didn't test with the trimmed version which is why I didn't have the problem :(

I think this is the correct way to fix it, if not lmk. I'm not really familiar with how trimming works. It does stop the errors at least.