### PR TITLE
Remove bustup param generic merging

### DIFF
--- a/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
+++ b/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
@@ -54,8 +54,8 @@ internal class P5RTblMerger : IFileMerger
             PatchAnyFile(pathToFileMap, @"R2\EVENT\EVTFADEOUTTABLE.BIN", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\PMCHATINVITE365TBL.DAT", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\RESOURCE\RESRCNPCTBL.BIN", 2, cpks),
-            PatchAnyFile(pathToFileMap, @"R2\BUSTUP\DATA\BUSTUP_PARAM.DAT", 4, cpks),
-            PatchAnyFile(pathToFileMap, @"R2\FONT\ASSIST\MSGASSISTBUSTUPPARAM.DAT", 4, cpks),
+            // PatchAnyFile(pathToFileMap, @"R2\BUSTUP\DATA\BUSTUP_PARAM.DAT", 4, cpks),
+            // PatchAnyFile(pathToFileMap, @"R2\FONT\ASSIST\MSGASSISTBUSTUPPARAM.DAT", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONA.PDD", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONAENEMY.PDD", 4, cpks)
         };

--- a/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
+++ b/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
@@ -54,6 +54,8 @@ internal class P5RTblMerger : IFileMerger
             PatchAnyFile(pathToFileMap, @"R2\EVENT\EVTFADEOUTTABLE.BIN", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\PMCHATINVITE365TBL.DAT", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\RESOURCE\RESRCNPCTBL.BIN", 2, cpks),
+            PatchAnyFile(pathToFileMap, @"R2\BUSTUP\DATA\BUSTUP_PARAM.DAT", 4, cpks),
+            PatchAnyFile(pathToFileMap, @"R2\FONT\ASSIST\MSGASSISTBUSTUPPARAM.DAT", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONA.PDD", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONAENEMY.PDD", 4, cpks)
         };

--- a/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
+++ b/p5rpc.modloader/Merging/Tbl/P5RTblMerger.cs
@@ -54,8 +54,6 @@ internal class P5RTblMerger : IFileMerger
             PatchAnyFile(pathToFileMap, @"R2\EVENT\EVTFADEOUTTABLE.BIN", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\PMCHATINVITE365TBL.DAT", 2, cpks),
             PatchAnyFile(pathToFileMap, @"R2\RESOURCE\RESRCNPCTBL.BIN", 2, cpks),
-            PatchAnyFile(pathToFileMap, @"R2\BUSTUP\DATA\BUSTUP_PARAM.DAT", 4, cpks),
-            PatchAnyFile(pathToFileMap, @"R2\FONT\ASSIST\MSGASSISTBUSTUPPARAM.DAT", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONA.PDD", 4, cpks),
             PatchAnyFile(pathToFileMap, @"R2\INIT\SHDPERSONAENEMY.PDD", 4, cpks)
         };

--- a/p5rpc.modloader/ModConfig.json
+++ b/p5rpc.modloader/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "p5rpc.modloader",
   "ModName": "Persona Essentials",
   "ModAuthor": "Sewer56",
-  "ModVersion": "2.9.2",
+  "ModVersion": "2.9.3",
   "ModDescription": "Mod which provides base modding support as well as miscellaneous basic quality of life fixes. See readme for Special Thanks!",
   "ModDll": "p5rpc.modloader.dll",
   "ModIcon": "Preview.png",


### PR DESCRIPTION
bustup param merging seems to cause some issues, needs a proper dedicated merging so in the meantime it should be removed from generic merging.